### PR TITLE
Fix Anthropic tool_result handling: emit role=tool messages and assistant tool_calls

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ os.chdir(BASE_DIR)
 
 load_dotenv()
 
-API_KEY = os.getenv("DEEPSEEKER_API_KEY", "dseeker")
+API_KEY = os.getenv("DEEPSEEKER_API_KEY") or "dseeker"
 ADMIN_USER = os.getenv("DEEPSEEKER_ADMIN_USER", "admin")
 ADMIN_PASSWORD = os.getenv("DEEPSEEKER_ADMIN_PASSWORD", "admin")
 
@@ -121,11 +121,6 @@ async def handle_chat(messages, model, thinking=False, search=False, stream=Fals
 
     sig = await generate_signature(messages, model, scope)
     sess = find_session(sig)
-    if not sess:
-        for i in range(len(messages) - 1, 0, -1):
-            sess = find_session(generate_signature_sync(messages[:i], model, scope))
-            if sess:
-                break
 
     if sess:
 
@@ -803,6 +798,73 @@ async def openai_responses(request: Request):
     return result
 
 
+def convert_anthropic_messages(messages):
+    """Translate Anthropic message dicts into OpenAI-style dicts.
+
+    tool_use blocks become assistant tool_calls and tool_result blocks become
+    role="tool" messages so that build_prompt()/extract_tool_results() see real
+    tool results and the signature cache can match across turns.
+    """
+    openai_msgs = []
+    for m in messages:
+        content = m.get("content", "")
+        tool_calls = []
+        tool_results = []
+        if isinstance(content, list):
+            parts = []
+            image_parts = []
+            for c in content:
+                if not isinstance(c, dict):
+                    continue
+                if c.get("type") == "text":
+                    parts.append(c.get("text", ""))
+                elif c.get("type") == "image":
+                    image_parts.append(c)
+                elif c.get("type") == "tool_use":
+                    tool_calls.append({
+                        "id": c.get("id") or ("call_" + uuid.uuid4().hex[:8]),
+                        "type": "function",
+                        "function": {
+                            "name": c.get("name", ""),
+                            "arguments": json.dumps(c.get("input", {})),
+                        },
+                    })
+                elif c.get("type") == "tool_result":
+                    res_content = c.get("content", "")
+                    if isinstance(res_content, list):
+                        for item in res_content:
+                            if isinstance(item, dict) and item.get("type") == "image":
+                                image_parts.append(item)
+                        res_content = " ".join(item.get("text", "") for item in res_content if isinstance(item, dict) and item.get("type") == "text")
+                    elif not isinstance(res_content, str):
+                        res_content = str(res_content)
+                    tool_results.append({"tool_call_id": c.get("tool_use_id", ""), "content": res_content})
+            if image_parts:
+                content = [{"type": "text", "text": s} for s in parts if s] + image_parts
+            else:
+                content = "\n".join(p for p in parts if p)
+        if m.get("role") == "system":
+            if content:
+                openai_msgs.append({"role": "system", "content": content})
+            continue
+        if m.get("role") == "assistant":
+            if isinstance(content, str) and (not content.strip() or content.strip() == "(no content)"):
+                content = None
+            msg = {"role": "assistant", "content": content}
+            if tool_calls:
+                msg["tool_calls"] = tool_calls
+            if msg["content"] is None and not tool_calls:
+                continue
+            openai_msgs.append(msg)
+            continue
+        for tr in tool_results:
+            openai_msgs.append({"role": "tool", "tool_call_id": tr["tool_call_id"], "content": tr["content"]})
+        has_content = bool(content) if not isinstance(content, list) else len(content) > 0
+        if has_content or not tool_results:
+            openai_msgs.append({"role": m.get("role", "user"), "content": content})
+    return openai_msgs
+
+
 @app.post("/v1/messages")
 @app.post("/messages")
 async def anthropic_messages(request: Request):
@@ -827,38 +889,7 @@ async def anthropic_messages(request: Request):
         if system_str:
             openai_msgs.append({"role": "system", "content": system_str})
 
-    for m in messages:
-        content = m.get("content", "")
-        if isinstance(content, list):
-            parts = []
-            image_parts = []
-            for c in content:
-                if isinstance(c, dict):
-                    if c.get("type") == "text":
-                        parts.append(c.get("text", ""))
-                    elif c.get("type") == "image":
-                        image_parts.append(c)
-                    elif c.get("type") == "tool_use":
-                        parts.append(f"{json.dumps({'name': c.get('name'), 'arguments': c.get('input', {})})}")
-                    elif c.get("type") == "tool_result":
-                        res_content = c.get("content", "")
-                        if isinstance(res_content, list):
-                            for item in res_content:
-                                if isinstance(item, dict) and item.get("type") == "image":
-                                    image_parts.append(item)
-                            res_content = " ".join(item.get("text", "") for item in res_content if isinstance(item, dict) and item.get("type") == "text")
-                        parts.append(f"[Tool Result for {c.get('tool_use_id', 'tool')}]: {res_content}")
-            if image_parts:
-                content = [{"type": "text", "text": s} for s in parts if s] + image_parts
-            else:
-                content = "\n".join(parts)
-        if m.get("role") == "system":
-            if content:
-                openai_msgs.append({"role": "system", "content": content})
-            continue
-        if m["role"] == "assistant" and (not content or content.strip() == "(no content)"):
-            continue
-        openai_msgs.append({"role": m["role"], "content": content})
+    openai_msgs.extend(convert_anthropic_messages(messages))
 
     openai_tools = []
     for t in tools:

--- a/tests/test_local_fixes.py
+++ b/tests/test_local_fixes.py
@@ -1,0 +1,117 @@
+"""Regression tests for the 2026-09-06 local fixes.
+
+Run with the repo venv:  deeperseeker_env/Scripts/python.exe tests/test_local_fixes.py
+(also pytest-compatible).
+"""
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app import API_KEY, convert_anthropic_messages
+from functions import parse_tools
+from plugin_helper import build_prompt, generate_signature_sync
+
+
+def test_api_key_never_empty():
+    assert API_KEY, "API_KEY must never be empty (fail-open)"
+    import importlib
+    import unittest.mock as mock
+    with mock.patch.dict(os.environ, {"DEEPSEEKER_API_KEY": ""}):
+        import app
+        importlib.reload(app)
+        assert app.API_KEY, "empty DEEPSEEKER_API_KEY must fall back to the default"
+    importlib.reload(app)
+
+
+def test_tool_result_becomes_tool_role():
+    msgs = [
+        {"role": "user", "content": "run it"},
+        {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {"command": "ls"}},
+        ]},
+        {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "toolu_1", "content": "file.txt"},
+        ]},
+    ]
+    out = convert_anthropic_messages(msgs)
+    assert out[1]["tool_calls"][0]["function"]["name"] == "Bash"
+    assert out[2]["role"] == "tool", "tool_result must become a role=tool message, not user text"
+    assert out[2]["tool_call_id"] == "toolu_1"
+    assert out[2]["content"] == "file.txt"
+
+
+def test_signature_matches_server_reconstruction():
+    # What the server reconstructs after parsing model output (as stream_response does)
+    model_output = 'Working on it.\n<tool_call>{"name": "Bash", "arguments": {"command": "ls -la"}}</tool_call>'
+    parsed_tools, clean_text = parse_tools(model_output)
+    assert parsed_tools, "parse_tools should find the tool call"
+    server_msgs = [
+        {"role": "user", "content": "run it"},
+        {"role": "assistant", "tool_calls": parsed_tools},
+    ]
+    # What an Anthropic client echoes back on the next turn
+    client_msgs = [
+        {"role": "user", "content": "run it"},
+        {"role": "assistant", "content": [
+            {"type": "text", "text": "Working on it."},
+            {"type": "tool_use", "id": "toolu_abc", "name": "Bash", "input": {"command": "ls -la"}},
+        ]},
+    ]
+    converted = convert_anthropic_messages(client_msgs)
+    assert generate_signature_sync(server_msgs, "expert") == generate_signature_sync(converted, "expert"), \
+        "signature cache must hit when the client echoes the assistant tool turn"
+
+
+def test_tool_results_reach_build_prompt():
+    msgs = [
+        {"role": "user", "content": "run it"},
+        {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {"command": "ls"}},
+        ]},
+        {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "toolu_1", "content": "file.txt"},
+        ]},
+    ]
+    converted = convert_anthropic_messages(msgs)
+    prompt = asyncio.run(build_prompt(converted, [], "expert", is_first_message=False))
+    assert "[TOOL RESULTS]" in prompt, "tool results must appear in the [TOOL RESULTS] section"
+    assert "file.txt" in prompt
+    assert "[USER]" not in prompt, "the original question must not be re-sent on follow-up turns"
+
+
+def test_user_text_after_tool_result_preserved():
+    msgs = [
+        {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {"command": "ls"}},
+        ]},
+        {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "toolu_1", "content": "a.txt"},
+            {"type": "text", "text": "now list the hidden files"},
+        ]},
+    ]
+    out = convert_anthropic_messages(msgs)
+    assert out[0]["role"] == "assistant" and out[0]["tool_calls"]
+    assert out[1]["role"] == "tool"
+    assert out[2]["role"] == "user"
+    assert out[2]["content"] == "now list the hidden files"
+
+
+def main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+    if failed:
+        sys.exit(1)
+    print(f"{len(tests)} tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

On the Anthropic-compatible `/v1/messages` endpoint, incoming `tool_result` blocks were flattened into plain text (`"[Tool Result for <id>]: ..."`) **inside a `role="user"` message**, and echoed assistant `tool_use` blocks were inlined as a JSON string in `content`.

Consequences for any Anthropic-SDK client doing agentic tool use:

- `extract_tool_results()` only recognizes OpenAI-style `role=="tool"` messages, so `build_prompt()`'s follow-up path never emits a `[TOOL RESULTS]` section — tool results reach the model mislabeled as user text, or (fallback path) the original question gets re-sent and the model repeats its previous answer in a loop.
- The session-cache signature reconstructs assistant turns as OpenAI `tool_calls`, while the client's echo canonicalizes as a content string — the two forms can never match, so the cache misses on **every** agentic turn, and the prefix-search fallback could bind the conversation to a stale session with a wrong `parent_message_id` (deterministic repeated answers).

## Fix

- New `convert_anthropic_messages()` helper translates Anthropic messages properly: `tool_use` → assistant `tool_calls` (OpenAI format), `tool_result` → `role="tool"` messages, so tool results reach `[TOOL RESULTS]` and the signature cache matches across turns.
- Removed the prefix-search session fallback in `handle_chat` — a cache miss now cleanly starts a fresh DeepSeek chat with full history injected instead of rebinding to a stale session.
- `API_KEY = os.getenv(...) or "dseeker"` — an empty `DEEPSEEKER_API_KEY` no longer fails open.

## Testing

This branch carries the code change only. The fork maintains a standalone regression suite (`tests/test_local_fixes.py`, runnable with the repo venv) that covers the conversion, the signature cache invariants (server-side reconstruction vs. client echo), and the fail-open fix.
