### PR TITLE
Centralize parent_message_id bookkeeping in next_parent() helper

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,6 +42,7 @@ from functions import (
     init_db,
     mark_limited,
     mark_active,
+    next_parent,
     parse_tools,
     pick_token,
     save_session,
@@ -163,8 +164,8 @@ async def handle_chat(messages, model, thinking=False, search=False, stream=Fals
                         next_messages.append(ast_msg)
                         next_sig = await generate_signature(next_messages, model, scope)
 
-                        save_session(sig, new_token_id, new_session_id, 2)
-                        save_session(next_sig, new_token_id, new_session_id, 2)
+                        save_session(sig, new_token_id, new_session_id, next_parent(0))
+                        save_session(next_sig, new_token_id, new_session_id, next_parent(0))
                         return format_response(resp_text, model, messages, tools)
     else:
 
@@ -216,8 +217,8 @@ async def handle_chat(messages, model, thinking=False, search=False, stream=Fals
             next_messages.append(ast_msg)
             next_sig = await generate_signature(next_messages, model, scope)
 
-            save_session(sig, token_id, session_id, parent_message_id + 2)
-            save_session(next_sig, token_id, session_id, parent_message_id + 2)
+            save_session(sig, token_id, session_id, next_parent(parent_message_id))
+            save_session(next_sig, token_id, session_id, next_parent(parent_message_id))
             return format_response(resp_text, model, messages, tools)
     except Exception as e:
         delete_session(sig)
@@ -333,8 +334,8 @@ async def stream_response(gen, model, messages, token_id, session_id, sig, tools
                 ast_msg["content"] = clean_text
             next_messages.append(ast_msg)
             next_sig = generate_signature_sync(next_messages, model, scope)
-            save_session(sig, token_id, session_id, parent_message_id + 2)
-            save_session(next_sig, token_id, session_id, parent_message_id + 2)
+            save_session(sig, token_id, session_id, next_parent(parent_message_id))
+            save_session(next_sig, token_id, session_id, next_parent(parent_message_id))
 
         if not aborted and not failed:
             try:
@@ -446,8 +447,8 @@ async def stream_anthropic_response(gen, model, messages, token_id, session_id, 
                 ast_msg["content"] = clean_text
             next_messages.append(ast_msg)
             next_sig = generate_signature_sync(next_messages, model, scope)
-            save_session(sig, token_id, session_id, parent_message_id + 2)
-            save_session(next_sig, token_id, session_id, parent_message_id + 2)
+            save_session(sig, token_id, session_id, next_parent(parent_message_id))
+            save_session(next_sig, token_id, session_id, next_parent(parent_message_id))
 
         def _tb(text):
             return (f"event: content_block_start\ndata: {json.dumps({'type': 'content_block_start', 'index': block_index_local[0], 'content_block': {'type': 'text', 'text': ''}})}\n\n"

--- a/functions.py
+++ b/functions.py
@@ -258,6 +258,22 @@ def delete_session(sig):
     conn.close()
 
 
+def next_parent(parent_message_id):
+    """Compute the parent_message_id to use for the next turn on a chat session.
+
+    Invariant: each successful /chat/completion request appends exactly one user
+    message and one assistant message to the DeepSeek chat session, so if the
+    request was sent with parent_message_id P, the last message id afterwards is
+    P + 1 and the next request must use P + 2.
+
+    DeepSeek's web API exposes no endpoint to list a session's messages, so this
+    increment cannot be verified against the server; it is centralized here so
+    every save_session() call site (token-rotation branch, non-stream and both
+    streaming paths) stays consistent if the invariant ever changes.
+    """
+    return parent_message_id + 2
+
+
 DEEPSEEK_TARIFFS = {
     "deepseek-v4-flash": {
         "cache_miss_input": 0.66,


### PR DESCRIPTION
## Problem

Every success path saved `parent_message_id + 2` inline (non-stream, both streaming `finally` blocks, and a hardcoded `2` in the token-rotation branch), encoding the invariant "one request = one user + one assistant message on DeepSeek's side" in six scattered places. Any future change to that invariant (multi-message turns, retries) has to be replicated everywhere and is easy to get wrong.

## Fix

- New `next_parent(parent_message_id)` helper in `functions.py` with the invariant documented (including the fact that DeepSeek's web API exposes no endpoint to verify it server-side).
- All `save_session` call sites in `app.py` now use it, so the bookkeeping has a single source of truth.
