### PR TITLE
Fix server freeze after many chats + cookie loss across restarts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,18 @@ DEEPSEEKER_ADMIN_PASSWORD=admin
 # Bind address for bare-metal runs (127.0.0.1 = local only, 0.0.0.0 = expose)
 HOST=127.0.0.1
 PORT=4000
+
+# --- Stability tunables (all optional; defaults shown) ---
+# Where the WAF cookie file is stored (Docker sets this to the volume)
+#DEEPSEEKER_COOKIE_PATH=/app/data/aws_cookies_deepseek.json
+# Cookie regeneration: attempts per cycle, per-cycle timeout (s), and the
+# fail-fast cooldown (s) after a failed cycle so requests error quickly
+# instead of queueing behind repeated browser launches
+#DEEPSEEKER_COOKIE_ATTEMPTS=2
+#DEEPSEEKER_COOKIE_TIMEOUT=120
+#DEEPSEEKER_COOKIE_COOLDOWN=20
+# Cap in-memory per-signature creation locks (memory-leak guard)
+#DEEPSEEKER_MAX_SIG_LOCKS=4096
+# Cap stored session signatures + prune frequency (DB-growth guard)
+#DEEPSEEKER_MAX_SESSIONS=20000
+#DEEPSEEKER_PRUNE_EVERY=500

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -101,3 +101,75 @@ fresh chat with compacted, token-capped history → single clean retry.
   prompt dedup/capping, tariff values, preflight/replay streaming, empty
   response detection, mocked `handle_chat` recovery + 429 path, tool-parser
   regressions.
+
+## 5. FOLLOW-UP BUG — Server freezes after many chats / cookies vanish across restarts (fixed)
+
+Reported: after enough chats the server stopped responding to **any** request
+(even brand-new chats), and after a mid-session restart the DeepSeek cookie
+file was missing from the data volume and never regenerated.
+
+Root causes found (all fixed):
+
+**a) Cookie file silently escaped the persistent volume** (`functions.py` +
+`Dockerfile`): the Docker image bridges `aws_cookies_deepseek.json` into
+`/app/data` via a **symlink**, but `_generate_cookies()` ends with
+`os.replace(tmp, "aws_cookies_deepseek.json")` — POSIX `rename()` does **not**
+follow symlinks, so the very first cookie write replaced the *symlink itself*
+with a plain file in the ephemeral container layer. The volume never received
+the cookie; any container recreation lost it permanently (SQLite writes
+*through* the symlink, which is why `deeperseeker.db` survived).
+→ Cookie path is now resolved (`cookie_file_path()`: `DEEPSEEKER_COOKIE_PATH`
+env > symlink target > directory of the real DB file) and the atomic
+`os.replace()` targets the **resolved** path, so the symlink is preserved.
+`Dockerfile` additionally sets `DB_PATH` / `DEEPSEEKER_COOKIE_PATH` to point
+straight into `/app/data`, making the symlinks unnecessary.
+
+**b) One failed cookie generation froze the whole server** (`functions.py`):
+`get_cookies()` serialized **every** request on `_cookie_lock` and each queued
+request re-attempted a full non-headless Chromium launch; when generation kept
+failing (missing/expired WAF token, display problems), requests queued
+indefinitely — the "server stops responding" symptom.
+→ `get_cookies()` now: double-checks under the lock; bounds each generation
+cycle (`DEEPSEEKER_COOKIE_TIMEOUT`, default 120s) and attempts
+(`DEEPSEEKER_COOKIE_ATTEMPTS`, default 2); arms a fail-fast cooldown
+(`DEEPSEEKER_COOKIE_COOLDOWN`, default 20s) so further requests error in
+milliseconds instead of queueing; falls back to a **stale** cookie file rather
+than hard-failing; raises a clear `CookieGenerationError` (mapped to HTTP 503
+by `_api_error_response`) when nothing is available.
+
+**c) Zero observability** (`functions.py` / `app.py`): cookie generation,
+rate-limit events and upstream failures failed silently, so nothing appeared
+in `docker logs`.
+→ Added `deeperseeker.functions` logging (generation start/success/failure
+with cause, cookie save path + expiry, token rate-limiting, session pruning,
+upstream non-200 responses, recovery failures) and `basicConfig` in `app.py`.
+
+**d) `_sig_locks` grew forever** (`app.py`): one `asyncio.Lock` per unique
+conversation signature, never evicted — a real memory leak after many chats.
+→ Capped at `DEEPSEEKER_MAX_SIG_LOCKS` (default 4096) with locked-entry-aware
+eviction of the oldest entries.
+
+**e) Sessions table grew forever** (`functions.py`): 2 rows stored per request
+with no cleanup; on volume-limited deployments a full disk also freezes all
+requests. → `prune_sessions()` keeps the newest `DEEPSEEKER_MAX_SESSIONS`
+(default 20000) rows, runs every `DEEPSEEKER_PRUNE_EVERY` (500) saves and once
+at startup; stale `session_map` rows older than 7 days are removed too.
+
+**f) `get_session()` double-init race** (`functions.py`): two concurrent
+first requests could create two `aiohttp.ClientSession`s (one leaked).
+→ Now guarded by a lock and re-checked for closed sessions.
+
+Net effect: cookies persist across restarts/recreations, a failing cookie
+regeneration degrades to fast, well-described 503s (and auto-retries) instead
+of a full-server freeze, and memory/DB growth is bounded.
+
+## 6. Verification (follow-up round)
+
+- `py_compile` clean on all modified files.
+- `tests/test_local_fixes.py` 5/5 (PR #11 regression suite).
+- 15/15 integration sanity checks (previous fix round).
+- 16/16 stability checks: symlink-safe cookie write (symlink survives atomic
+  replace, file lands in the volume), regeneration on missing file, fail-fast
+  cooldown with root-cause message, stale-cookie fallback, shared-session
+  double-init race, lock-cap eviction (held locks preserved), session pruning
+  to cap with oldest-first eviction.

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,13 @@ RUN mkdir -p /app/data && \
 
 EXPOSE 4000
 
+# Persist both state files DIRECTLY in the mounted volume (/app/data). The old
+# symlink bridge broke: os.replace() on the cookie path did not follow the
+# symlink and wrote into the container layer instead, so cookies were lost on
+# every container recreation. Explicit env paths avoid the symlink entirely.
+ENV DB_PATH=/app/data/deeperseeker.db
+ENV DEEPSEEKER_COOKIE_PATH=/app/data/aws_cookies_deepseek.json
+
 ENV HOST=0.0.0.0
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 CMD curl -sf http://localhost:4000/health || exit 1

--- a/app.py
+++ b/app.py
@@ -31,6 +31,8 @@ security = HTTPBasic()
 
 
 from functions import (
+    CookieGenerationError,
+    cookie_file_path,
     add_token,
     count_tokens,
     create_new_chat,
@@ -56,6 +58,14 @@ from plugin_helper import build_prompt, extract_and_upload_files, generate_signa
 
 
 logger = logging.getLogger("uvicorn.error")
+
+# Surface deeperseeker.* logs (cookie generation, prunes, rate-limit events,
+# upstream failures) alongside uvicorn's own output, unless already configured.
+if not logging.getLogger().handlers:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
 
 
 def count_tok(text):
@@ -83,7 +93,13 @@ async def limit_body_size(request: Request, call_next):
 
 SESSIONS = {}
 SESSION_TTL = 7 * 24 * 3600
+# One asyncio.Lock per conversation signature, used to serialize first-time
+# session creation. Signatures are unique per message prefix, so without a cap
+# this dict grows FOREVER — after many chats it becomes a serious memory leak.
+# When the cap is hit, the oldest half of currently-unlocked entries is
+# evicted (worst case: an extra benign session re-creation).
 _sig_locks = {}
+SIG_LOCKS_MAX = int(os.getenv("DEEPSEEKER_MAX_SIG_LOCKS", "4096"))
 _login_fails = {"count": 0, "locked_until": 0}
 
 
@@ -118,6 +134,8 @@ def check_key(request: Request):
 def _api_error_response(e, is_anthropic=False):
     m = re.match(r"HTTP (\d{3}):", str(e))
     code = int(m.group(1)) if m else 502
+    if isinstance(e, CookieGenerationError):
+        code = 503  # WAF cookies cannot be produced right now — upstream unreachable, not a client error
     if code < 400 or code > 599:
         code = 502
     if is_anthropic:
@@ -173,6 +191,7 @@ async def handle_chat(messages, model, thinking=False, search=False, stream=Fals
                         gen = send_message(new_session_id, new_tok["token"], prompt, 0, thinking, search, None if model == "instant" else model, file_ids)
                         gen = await _preflight_stream(gen)
                     except Exception as e:
+                        logger.exception("Token-rotation recovery failed (chat %s): %s", session_id, e)
                         if _retried:
                             return _api_error_response(e, is_anthropic)
                         return await handle_chat(messages, model, thinking, search, stream, tools, is_anthropic, req_model, scope, _retried=True)
@@ -184,6 +203,7 @@ async def handle_chat(messages, model, thinking=False, search=False, stream=Fals
                         try:
                             resp_text = await collect_response(gen)
                         except Exception as e:
+                            logger.exception("Upstream failed during token-rotation request: %s", e)
                             if _retried:
                                 return _api_error_response(e, is_anthropic)
                             return await handle_chat(messages, model, thinking, search, stream, tools, is_anthropic, req_model, scope, _retried=True)
@@ -207,6 +227,13 @@ async def handle_chat(messages, model, thinking=False, search=False, stream=Fals
             return JSONResponse({"error": {"message": "No active tokens available (all rate limited). Try again later.", "type": "rate_limit_error"}}, status_code=429)
     else:
 
+        while len(_sig_locks) >= SIG_LOCKS_MAX:
+            chunk = list(_sig_locks.items())[: SIG_LOCKS_MAX // 2 + 1]
+            evictable = [k for k, v in chunk if not v.locked()]
+            if not evictable:
+                break  # everything in the chunk is in use; retry on a later request
+            for k in evictable:
+                _sig_locks.pop(k, None)
         create_lock = _sig_locks.setdefault(sig, asyncio.Lock())
         async with create_lock:
             sess = find_session(sig)
@@ -260,6 +287,7 @@ async def handle_chat(messages, model, thinking=False, search=False, stream=Fals
             save_session(next_sig, token_id, session_id, next_parent(parent_message_id))
             return format_response(resp_text, model, messages, tools)
     except Exception as e:
+        logger.exception("Chat request failed (session %s, parent %s): %s", session_id, parent_message_id, e)
         m = re.match(r"HTTP (\d{3}):", str(e))
         code = int(m.group(1)) if m else None
         if code in (401, 403, 429):
@@ -1178,7 +1206,7 @@ async def health(request: Request):
     active = sum(1 for t in get_tokens() if t["status"] == "ACTIVE")
     cookies_valid = False
     try:
-        with open("aws_cookies_deepseek.json") as f:
+        with open(cookie_file_path()) as f:
             c = json.load(f)
         exp = c.get("expiry")
         cookies_valid = bool(exp and exp > time.time())

--- a/functions.py
+++ b/functions.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import json
+import logging
 import mimetypes
 import os
 import random
@@ -15,9 +16,36 @@ import deepseek_tokenizer
 import wasmtime
 from playwright.async_api import async_playwright
 
+logger = logging.getLogger("deeperseeker.functions")
+
 wasm_path = "wasm/deepseek_pow_solver.wasm"
 _session = None
-_db = "deeperseeker.db"
+_db = os.getenv("DB_PATH", "deeperseeker.db")
+
+
+def cookie_file_path():
+    """Resolve where the DeepSeek cookie file lives.
+
+    Order: DEEPSEEKER_COOKIE_PATH env > the target of a legacy Docker symlink
+    > next to the real DB file (which honors DB_PATH) > CWD. Writing goes to
+    the RESOLVED path so os.replace() can never destroy a symlink that bridges
+    the file into the persistent data volume.
+    """
+    p = os.getenv("DEEPSEEKER_COOKIE_PATH")
+    if p:
+        return p
+    p = "aws_cookies_deepseek.json"
+    try:
+        if os.path.islink(p):
+            target = os.path.realpath(p)
+            if target:
+                return target
+    except Exception:
+        pass
+    d = os.path.dirname(os.path.abspath(_db))
+    if d and os.path.abspath(d) != os.path.abspath(os.getcwd()):
+        return os.path.join(d, "aws_cookies_deepseek.json")
+    return p
 
 try:
     _TZ_OFFSET = str(int(datetime.now().astimezone().utcoffset().total_seconds()))
@@ -59,12 +87,22 @@ def init_db():
     """)
     conn.commit()
     conn.close()
+    try:
+        prune_sessions()
+    except Exception:
+        logger.exception("Startup session pruning failed (non-fatal)")
+
+
+_session_lock = asyncio.Lock()
 
 
 async def get_session():
     global _session
-    if _session is None:
-        _session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=None, connect=15, sock_read=600))
+    if _session is None or _session.closed:
+        async with _session_lock:
+            if _session is None or _session.closed:
+                logger.info("Opening shared aiohttp ClientSession")
+                _session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=None, connect=15, sock_read=600))
     return _session
 
 
@@ -98,30 +136,94 @@ def get_headers(auth_token, pow=None):
 
 _cookie_lock = asyncio.Lock()
 
+# Tunables for cookie generation resilience (the previous failure mode: one
+# failed generation serialized EVERY request behind _cookie_lock forever, so
+# the whole server stopped responding — even to brand-new chats).
+COOKIE_REGEN_ATTEMPTS = int(os.getenv("DEEPSEEKER_COOKIE_ATTEMPTS", "2"))
+COOKIE_REGEN_TIMEOUT = float(os.getenv("DEEPSEEKER_COOKIE_TIMEOUT", "120"))
+COOKIE_FAIL_COOLDOWN = float(os.getenv("DEEPSEEKER_COOKIE_COOLDOWN", "20"))
 
-async def get_cookies():
+_cookie_fail = {"until": 0.0, "error": ""}
+
+
+class CookieGenerationError(Exception):
+    """Raised when the DeepSeek WAF cookie file cannot be produced."""
+
+
+def _read_cookie_file():
+    """Return valid (unexpired) cookies, or None."""
     try:
-        if os.path.exists("aws_cookies_deepseek.json"):
-            with open("aws_cookies_deepseek.json") as f:
-                cookies = json.load(f)
-            if cookies.get("expiry") is not None and cookies["expiry"] > time.time():
-                return cookies["cookie"]
+        with open(cookie_file_path()) as f:
+            c = json.load(f)
+        if c.get("expiry") is not None and c["expiry"] > time.time():
+            return c["cookie"]
     except Exception:
         pass
+    return None
+
+
+def _read_stale_cookie_file():
+    """Return cookies even if expired (last-resort fallback)."""
+    try:
+        with open(cookie_file_path()) as f:
+            c = json.load(f)
+        return c.get("cookie") or None
+    except Exception:
+        return None
+
+
+async def get_cookies():
+    cookies = _read_cookie_file()
+    if cookies:
+        return cookies
+
+    def _cooldown_error():
+        return CookieGenerationError(
+            _cookie_fail["error"] + " (cooling down; will retry automatically — try again shortly)"
+        )
+
+    # Fail fast while a regeneration attempt recently failed, instead of
+    # queueing every request behind a full Chromium launch that will fail again.
+    if time.time() < _cookie_fail["until"]:
+        stale = _read_stale_cookie_file()
+        if stale:
+            return stale
+        raise _cooldown_error()
     async with _cookie_lock:
-        fresh = False
-        try:
-            if os.path.exists("aws_cookies_deepseek.json"):
-                with open("aws_cookies_deepseek.json") as f:
-                    cookies = json.load(f)
-                fresh = cookies.get("expiry") is not None and cookies["expiry"] > time.time()
-        except Exception:
-            fresh = False
-        if not fresh:
-            await _generate_cookies()
-        with open("aws_cookies_deepseek.json") as f:
-            cookies = json.load(f)
-        return cookies["cookie"]
+        cookies = _read_cookie_file()
+        if cookies:
+            return cookies
+        if time.time() < _cookie_fail["until"]:
+            stale = _read_stale_cookie_file()
+            if stale:
+                return stale
+            raise _cooldown_error()
+        last_err = None
+        for attempt in range(1, COOKIE_REGEN_ATTEMPTS + 1):
+            try:
+                logger.info("Generating DeepSeek cookies (attempt %d/%d)...", attempt, COOKIE_REGEN_ATTEMPTS)
+                await asyncio.wait_for(_generate_cookies(), timeout=COOKIE_REGEN_TIMEOUT)
+                cookies = _read_cookie_file()
+                if cookies:
+                    _cookie_fail["until"] = 0.0
+                    _cookie_fail["error"] = ""
+                    return cookies
+                last_err = CookieGenerationError("cookie file missing/invalid after generation")
+            except Exception as e:
+                last_err = e
+                logger.warning("DeepSeek cookie generation attempt %d/%d failed: %s", attempt, COOKIE_REGEN_ATTEMPTS, e)
+            if attempt < COOKIE_REGEN_ATTEMPTS:
+                await asyncio.sleep(min(5 * attempt, 10))
+        _cookie_fail["until"] = time.time() + COOKIE_FAIL_COOLDOWN
+        _cookie_fail["error"] = f"Could not generate DeepSeek cookies: {last_err}"
+        logger.error("%s", _cookie_fail["error"])
+        # Last resort: stale cookies may still be accepted upstream — better
+        # than hard-failing every request.
+        stale = _read_stale_cookie_file()
+        if stale:
+            logger.warning("Serving STALE DeepSeek cookies after generation failure (upstream may reject them)")
+            return stale
+        raise CookieGenerationError(_cookie_fail["error"])
 
 
 async def _generate_cookies():
@@ -133,8 +235,8 @@ async def _generate_cookies():
         try:
             context = await browser.new_context()
             page = await context.new_page()
-            await page.goto("https://chat.deepseek.com/", wait_until="domcontentloaded")
-            await page.wait_for_selector("body")
+            await page.goto("https://chat.deepseek.com/", wait_until="domcontentloaded", timeout=45000)
+            await page.wait_for_selector("body", timeout=30000)
             try:
                 await page.wait_for_url("**/sign_in*", timeout=30000)
             except Exception:
@@ -151,10 +253,20 @@ async def _generate_cookies():
     final_cookies["ds_cookie_preference"] = "%257B%2522level%2522%253A%2522all%2522%257D"
     if not expiry or expiry < 0:
         expiry = time.time() + 1800
-    tmp_path = "aws_cookies_deepseek.json.tmp"
+    # Resolve the REAL storage path first: the Docker image bridges the cookie
+    # file into the persistent volume via a symlink at /app, and os.replace()
+    # (rename) does NOT follow symlinks — the old code replaced the symlink
+    # itself with a plain file in the container layer, so cookies were lost on
+    # every container recreation. Write the tmp file next to the target and
+    # atomically replace the resolved path instead.
+    target = cookie_file_path()
+    target_dir = os.path.dirname(os.path.abspath(target))
+    os.makedirs(target_dir, exist_ok=True)
+    tmp_path = os.path.join(target_dir, os.path.basename(target) + ".tmp")
     with open(tmp_path, "w") as f:
         f.write(json.dumps({"cookie": final_cookies, "expiry": expiry}))
-    os.replace(tmp_path, "aws_cookies_deepseek.json")
+    os.replace(tmp_path, target)
+    logger.info("DeepSeek cookies saved to %s (expires %s)", target, datetime.fromtimestamp(expiry) if expiry else "n/a")
 
 
 def get_auth_token():
@@ -218,6 +330,7 @@ def pick_token():
 
 
 def mark_limited(token_id):
+    logger.warning("Token #%d marked RATE_LIMITED", token_id)
     conn = get_db()
     conn.execute("UPDATE tokens SET status = ? WHERE id = ?", ("RATE_LIMITED", token_id))
     conn.commit()
@@ -240,6 +353,34 @@ def find_session(sig):
     return None
 
 
+# Cap on stored session signatures. Every request stores 2 rows and nothing
+# ever removed them, so after many chats the SQLite file (and its WAL) grew
+# unbounded — on volume-limited deployments a full disk freezes ALL requests,
+# including brand-new chats. PRUNE_EVERY saves trigger a prune that keeps the
+# newest MAX_SESSIONS rows (rowid order = insertion order).
+MAX_SESSIONS = int(os.getenv("DEEPSEEKER_MAX_SESSIONS", "20000"))
+PRUNE_EVERY = int(os.getenv("DEEPSEEKER_PRUNE_EVERY", "500"))
+_save_counter = {"n": 0}
+
+
+def prune_sessions():
+    conn = get_db()
+    try:
+        deleted = conn.execute(
+            "DELETE FROM sessions WHERE rowid NOT IN "
+            "(SELECT rowid FROM sessions ORDER BY rowid DESC LIMIT ?)",
+            (MAX_SESSIONS,),
+        ).rowcount
+        deleted_map = conn.execute(
+            "DELETE FROM session_map WHERE created_at < datetime('now', '-7 days')"
+        ).rowcount
+        conn.commit()
+        if deleted or deleted_map:
+            logger.info("Pruned %d session signature(s) and %d stale session_map row(s)", deleted, deleted_map)
+    finally:
+        conn.close()
+
+
 def save_session(sig, token_id, session_id, parent_message_id=0):
     conn = get_db()
     conn.execute(
@@ -249,6 +390,13 @@ def save_session(sig, token_id, session_id, parent_message_id=0):
     )
     conn.commit()
     conn.close()
+    _save_counter["n"] += 1
+    if _save_counter["n"] >= PRUNE_EVERY:
+        _save_counter["n"] = 0
+        try:
+            prune_sessions()
+        except Exception:
+            logger.exception("Session pruning failed (non-fatal)")
 
 
 def delete_session(sig):
@@ -795,6 +943,7 @@ async def send_message(chat_id, auth_token, message, parent_message_id, thinking
     async with session.post(url, cookies=cookie, headers=headers, json=json_data) as r:
         if r.status != 200:
             error_text = await r.text()
+            logger.warning("DeepSeek completion HTTP %d for chat %s: %s", r.status, chat_id, error_text[:300])
             raise Exception(f"HTTP {r.status}: {error_text}")
 
         async for line in r.content:


### PR DESCRIPTION
# Fix server freeze after many chats + cookie loss across restarts

Follow-up to #14 (long-context fix, merged). This round fixes the two production issues reported after running #14: **the server stopped responding to any request after many chats (even brand-new ones)**, and **the DeepSeek cookie file went missing from the data volume after a restart and was never regenerated**.

## Root causes fixed

| # | Root cause | Fix |
|---|-----------|-----|
| a | **Cookies silently escaped the persistent volume** (`functions.py` + `Dockerfile`) | The image bridges `aws_cookies_deepseek.json` into `/app/data` via a symlink, but `_generate_cookies()` ended with `os.replace(tmp, ...)` — POSIX `rename()` does **not** follow symlinks, so the first cookie write replaced the *symlink itself* with a plain file in the ephemeral container layer. Cookies were lost on every container recreation (SQLite writes *through* the symlink, which is why `deeperseeker.db` survived). Now: `cookie_file_path()` resolves the real target (`DEEPSEEKER_COOKIE_PATH` env > symlink target > next to the real DB file) and the atomic replace targets it; `Dockerfile` sets `DB_PATH` / `DEEPSEEKER_COOKIE_PATH` directly to the volume so symlinks are no longer load-bearing |
| b | **One failed cookie generation froze the whole server** (`functions.py`) | `get_cookies()` serialized *every* request on `_cookie_lock` and each queued request re-attempted a full non-headless Chromium launch — when generation kept failing, requests queued indefinitely. Now generation is bounded (`DEEPSEEKER_COOKIE_TIMEOUT` 120s, `DEEPSEEKER_COOKIE_ATTEMPTS` 2), a fail-fast cooldown (`DEEPSEEKER_COOKIE_COOLDOWN` 20s) turns later requests into millisecond errors instead of a browser-launch queue, a **stale** cookie file is served as last resort, and `CookieGenerationError` maps to a clean HTTP 503 carrying the root cause |
| c | **Zero observability** (`functions.py` / `app.py`) | New `deeperseeker.functions` logger: cookie generation start/success/failure (with cause), save path + expiry, token rate-limiting, session pruning, upstream non-200s, recovery failures; `logging.basicConfig` wired in `app.py` — failures are now visible in `docker logs` |
| d | **Unbounded memory growth** (`app.py`) | `_sig_locks` held one `asyncio.Lock` per unique conversation signature forever — after many chats it becomes a serious leak. Capped at `DEEPSEEKER_MAX_SIG_LOCKS` (4096) with held-lock-aware eviction |
| e | **Unbounded DB growth** (`functions.py`) | The `sessions` table stored 2 rows per request with no cleanup; on volume-limited deployments a full disk also freezes all requests. `prune_sessions()` keeps the newest `DEEPSEEKER_MAX_SESSIONS` (20000) rows, runs every `DEEPSEEKER_PRUNE_EVERY` (500) saves and at startup; `session_map` rows older than 7 days are removed |
| f | **`get_session()` double-init race** (`functions.py`) | Two concurrent first requests could create two `aiohttp.ClientSession`s (one leaked). Now lock-guarded and re-checked for closed sessions |

## New env tunables (all optional, documented in `.env.example`)

`DEEPSEEKER_COOKIE_PATH`, `DEEPSEEKER_COOKIE_ATTEMPTS`, `DEEPSEEKER_COOKIE_TIMEOUT`, `DEEPSEEKER_COOKIE_COOLDOWN`, `DEEPSEEKER_MAX_SIG_LOCKS`, `DEEPSEEKER_MAX_SESSIONS`, `DEEPSEEKER_PRUNE_EVERY`

## Verification

- `py_compile` clean on all modified files
- `tests/test_local_fixes.py` — 5/5 pass (existing regression suite)
- 15/15 integration sanity checks from #14 still pass
- 16/16 new stability checks: symlink survives the atomic cookie replace and the file lands in the volume; regeneration when missing; fail-fast cooldown with root-cause message; stale-cookie fallback; shared-session double-init race; lock-cap eviction (held locks preserved); session pruning to cap, oldest first

Full details in [`CHANGES.md`](./CHANGES.md), section 5.
