### PR TITLE
Fix DSML tool streaming edge cases

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -696,6 +696,22 @@ def parse_tools(text):
     return tools, clean_text
 
 
+# Family-wide closer pattern for the tool-call wrapper family, including
+# the |/｜-decorated variants that parse_tools accepts. Used by
+# StreamToolParser so a mismatched closer closes the open block instead of
+# hanging until flush(). [FIX 3]
+_TOOL_END_TAG_RE = re.compile(
+    r"</[｜\|]{0,2}(?:DSML[｜\|]{0,2})?(?:tool_calls?|invoke|function_call)>",
+    re.IGNORECASE,
+)
+
+# [FIX 2] Hard bound (chars) on how much text feed() may hold back while the
+# buffer tail still looks like the prefix of a start tag. The longest start
+# tag is 13 chars; 15 leaves headroom so future tag edits cannot reintroduce
+# unbounded buffering on prose like "if x < y".
+_MAX_TAG_HOLD = 15
+
+
 class StreamToolParser:
     def __init__(self):
         self.buffer = ""
@@ -708,21 +724,18 @@ class StreamToolParser:
         results = []
         while True:
             if self.in_tool:
-                end_tags = ["</tool_call>", "</function_call>", "</invoke>", "</tool_calls>"]
-                end_pos = -1
-                end_tag_len = 0
-                for tag in end_tags:
-                    idx = self.buffer.find(tag)
-                    if idx != -1 and (end_pos == -1 or idx < end_pos):
-                        end_pos = idx
-                        end_tag_len = len(tag)
-                if end_pos != -1:
+                # [FIX 3] Family-wide closer fallback: accept ANY wrapper closer
+                # the tool-call family can emit (including |/｜-decorated
+                # variants parse_tools tolerates) instead of hanging an open
+                # block until flush() when the model closes with a wrong tag.
+                end_match = _TOOL_END_TAG_RE.search(self.buffer)
+                if end_match:
                     if not self.json_done:
-                        tool_xml = self.buffer[:end_pos + end_tag_len]
+                        tool_xml = self.buffer[: end_match.end()]
                         parsed, _ = parse_tools(tool_xml)
                         for item in parsed:
                             results.append({"tool": item})
-                    self.buffer = self.buffer[end_pos + end_tag_len:]
+                    self.buffer = self.buffer[end_match.end():]
                     self.in_tool = False
                     self.json_done = False
                     continue
@@ -754,9 +767,13 @@ class StreamToolParser:
                     self.in_tool = True
                     self.has_tool = True
                     continue
+                # [FIX 2] Only hold a tail that is a genuine prefix of a start
+                # tag, and never hold more than _MAX_TAG_HOLD characters, so
+                # prose with a bare '<' (e.g. "if x < y") keeps streaming
+                # instead of buffering until flush().
                 hold = 0
                 for tag in start_tags:
-                    for i in range(1, len(tag)):
+                    for i in range(1, min(len(tag), _MAX_TAG_HOLD + 1)):
                         if self.buffer.endswith(tag[:i]):
                             hold = max(hold, i)
                 if hold:
@@ -776,10 +793,29 @@ class StreamToolParser:
         if self.buffer and not self.in_tool:
             out.append({"text": self.buffer})
         elif self.in_tool:
-            stripped = re.sub(r"</?[｜\|]{0,2}(?:DSML[｜\|]{0,2})?(?:tool_call|invoke|function_call|parameter)[^>]*>", "", self.buffer, flags=re.IGNORECASE).strip()
-            if stripped:
-                out.append({"text": stripped})
+            # [FIX 1] Recover the tool before stripping: if the stream was cut
+            # off before the closing tag arrived but the payload itself is
+            # parseable, emit the tool call instead of dumping raw parameter
+            # values into the chat text. Strip only when nothing parses.
+            parsed, _ = parse_tools(self.buffer)
+            if parsed:
+                for item in parsed:
+                    out.append({"tool": item})
+            elif not self.json_done:
+                stripped = re.sub(
+                    r"</?[｜\|]{0,2}(?:DSML[｜\|]{0,2})?(?:tool_call|invoke|function_call|parameter)[^>]*>",
+                    "",
+                    self.buffer,
+                    flags=re.IGNORECASE,
+                ).strip()
+                if stripped:
+                    out.append({"text": stripped})
+            # With json_done set, whatever is left after the consumed JSON
+            # payload is wrapper noise (partial closers / whitespace) and is
+            # dropped instead of leaking into the chat text.
         self.buffer = ""
+        self.in_tool = False
+        self.json_done = False
         return out
 
 

--- a/tests/test_stream_edge_cases.py
+++ b/tests/test_stream_edge_cases.py
@@ -1,0 +1,224 @@
+"""Regression tests for the streaming edge-case fixes (FIX 1/2/3).
+
+Covers the three review items on StreamToolParser:
+
+  FIX 1: flush() falls back to parse_tools(self.buffer) before stripping tags,
+         so a stream cut off before the closing tag still yields the tool.
+  FIX 2: the tag-prefix hold is explicitly bounded (_MAX_TAG_HOLD) and bare '<'
+         prose keeps streaming instead of buffering until flush().
+  FIX 3: family-wide closer fallback (regex) accepts mismatched and |/｜-decorated
+         closers during feed() instead of hanging until flush().
+
+Run:  python tests/test_stream_edge_cases.py   (pytest-compatible)
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from functions import StreamToolParser, _MAX_TAG_HOLD  # noqa: E402
+
+OPEN = "<"  # guard against editor/tooling eating angle-bracket literals
+CLOSE = ">"
+
+
+def xml(s):
+    return s.replace("[LT]", "<").replace("[GT]", ">")
+
+
+def feed_all(parser, text, size):
+    text_out, tools_out = [], []
+    for i in range(0, len(text), size):
+        for r in parser.feed(text[i : i + size]):
+            if "text" in r:
+                text_out.append(r["text"])
+            else:
+                tools_out.append(r["tool"])
+    return "".join(text_out), tools_out
+
+
+def flush_all(parser):
+    text_out, tools_out = [], []
+    for r in parser.flush():
+        if "text" in r:
+            text_out.append(r["text"])
+        else:
+            tools_out.append(r["tool"])
+    return "".join(text_out), tools_out
+
+
+def names(tools):
+    return [t["function"]["name"] for t in tools]
+
+
+def args_of(tools, i=0):
+    import json
+
+    return json.loads(tools[i]["function"]["arguments"])
+
+
+def test_fix1_flush_salvages_attribute_style_tool():
+    """Attribute-style tool cut off before the closer: flush() must emit the tool,
+    not dump raw parameter values as chat text."""
+    corpus = xml('[LT]tool_call name="Bash"[GT][LT]parameter name="command"[GT]ls -la[LT]/parameter[GT]')
+    p = StreamToolParser()
+    text, tools = feed_all(p, corpus, 7)
+    assert tools == [] and text == "", "nothing should be emitted before flush"
+    f_text, f_tools = flush_all(p)
+    assert names(f_tools) == ["Bash"], f"expected tool from flush, got {f_tools}"
+    assert args_of(f_tools) == {"command": "ls -la"}
+    assert f_text == "", f"no parameter values may leak as text, got {f_text!r}"
+
+
+def test_fix1_flush_salvages_truncated_json_tool():
+    """JSON-style tool whose arguments JSON is brace-truncated: flush() recovers
+    the tool via parse_tools' brace-balancing fallback."""
+    corpus = xml('[LT]tool_call[GT]{"name": "Bash", "arguments": {"command": "ls"')
+    p = StreamToolParser()
+    feed_all(p, corpus, 5)
+    f_text, f_tools = flush_all(p)
+    assert names(f_tools) == ["Bash"], f"expected salvaged tool, got {f_tools}"
+    assert args_of(f_tools) == {"command": "ls"}
+
+
+def test_fix1_flush_drops_wrapper_noise_after_json():
+    """Tool already emitted via the JSON path; leftover partial closer at EOF must
+    not leak into chat text."""
+    corpus = xml('[LT]tool_call[GT]{"name": "Bash", "arguments": {}}[LT]/tool_')
+    p = StreamToolParser()
+    _, tools = feed_all(p, corpus, 9)
+    assert names(tools) == ["Bash"]
+    f_text, f_tools = flush_all(p)
+    assert f_tools == [] and f_text == "", f"wrapper noise leaked: {f_text!r}"
+
+
+def test_fix1_flush_unparseable_still_strips_to_text():
+    """When nothing parses (no name attribute, no JSON), legacy behaviour stands:
+    strip wrapper tags, dump the remainder as text."""
+    corpus = xml('[LT]tool_call[GT]not a tool body')
+    p = StreamToolParser()
+    feed_all(p, corpus, 4)
+    f_text, f_tools = flush_all(p)
+    assert f_tools == []
+    assert f_text == "not a tool body", repr(f_text)
+
+
+def test_fix2_prose_with_bare_lt_streams_immediately():
+    corpus = "if x < y then a > b"
+    p = StreamToolParser()
+    text, tools = feed_all(p, corpus, 2)
+    assert tools == []
+    assert text == corpus, f"bare '<' must not buffer prose, got {text!r}"
+    f_text, _ = flush_all(p)
+    assert f_text == ""
+
+
+def test_fix2_hold_is_bounded():
+    """A tail that keeps looking like a tag prefix can never buffer more than
+    _MAX_TAG_HOLD characters."""
+    assert _MAX_TAG_HOLD <= 15, "review asked for a ~15-char bound"
+    corpus = "a <" + "z" * 200
+    p = StreamToolParser()
+    text, _ = feed_all(p, corpus, 3)
+    f_text, _ = flush_all(p)
+    assert text + f_text == corpus
+
+
+def test_fix2_partial_prefix_released_as_prose():
+    corpus = xml("use [LT]tool_ in prose")
+    p = StreamToolParser()
+    text, _ = feed_all(p, corpus, 3)
+    f_text, _ = flush_all(p)
+    assert text + f_text == corpus
+
+
+def test_fix3_mismatched_plain_closer():
+    """</tool_calls> must close a <tool_call> block during feed (regression lock)."""
+    corpus = xml('[LT]tool_call[GT]{"name": "Bash", "arguments": {"command": "ls"}}[LT]/tool_calls[GT]')
+    p = StreamToolParser()
+    text, tools = feed_all(p, corpus, 5)
+    assert names(tools) == ["Bash"], f"mismatched closer must not hang, got {tools}"
+    f_text, f_tools = flush_all(p)
+    assert f_tools == [] and text == ""
+
+
+def test_fix3_decorated_closer_halfwidth():
+    """</|tool_call|> must close the block during feed, not just by JSON accident."""
+    corpus = xml('[LT]tool_call name="Bash"[GT][LT]parameter name="command"[GT]ls[LT]/parameter[GT][LT]/|tool_call[GT]')
+    p = StreamToolParser()
+    text, tools = feed_all(p, corpus, 6)
+    assert names(tools) == ["Bash"], f"decorated closer must close block, got {tools}"
+    assert args_of(tools) == {"command": "ls"}
+    f_text, f_tools = flush_all(p)
+    assert f_tools == [] and text == ""
+
+
+def test_fix3_decorated_closer_fullwidth():
+    """</｜tool_call｜> (fullwidth bars) must also close the block during feed."""
+    corpus = xml('[LT]tool_call name="Read"[GT][LT]parameter name="path"[GT]/tmp/a[LT]/parameter[GT][LT]/｜tool_call[GT]')
+    p = StreamToolParser()
+    text, tools = feed_all(p, corpus, 4)
+    assert names(tools) == ["Read"], tools
+    assert args_of(tools) == {"path": "/tmp/a"}
+
+
+def test_fix3_cross_family_closer():
+    """</invoke> must close a <function_call> block (family-wide fallback)."""
+    corpus = xml('[LT]function_call[GT]{"name": "Bash", "arguments": {}}[LT]/invoke[GT]')
+    p = StreamToolParser()
+    text, tools = feed_all(p, corpus, 7)
+    assert names(tools) == ["Bash"], tools
+
+
+def test_flush_is_terminal_and_resets_state():
+    p = StreamToolParser()
+    feed_all(p, xml('[LT]tool_call name="Bash"[GT][LT]parameter name="command"[GT]ls[LT]/parameter[GT]'), 5)
+    p.flush()
+    assert p.buffer == "" and not p.in_tool and not p.json_done
+    assert p.flush() == []
+
+
+def test_complete_blocks_unchanged():
+    """Guard: happy-path behaviour is untouched."""
+    corpus = xml('Working.[LT]tool_call[GT]{"name": "Bash", "arguments": {"command": "ls -la"}}[LT]/tool_call[GT]Done.')
+    p = StreamToolParser()
+    text, tools = feed_all(p, corpus, 6)
+    assert names(tools) == ["Bash"] and args_of(tools) == {"command": "ls -la"}
+    f_text, f_tools = flush_all(p)
+    assert text + f_text == "Working.Done."
+    assert f_tools == []
+
+
+TESTS = [
+    test_fix1_flush_salvages_attribute_style_tool,
+    test_fix1_flush_salvages_truncated_json_tool,
+    test_fix1_flush_drops_wrapper_noise_after_json,
+    test_fix1_flush_unparseable_still_strips_to_text,
+    test_fix2_prose_with_bare_lt_streams_immediately,
+    test_fix2_hold_is_bounded,
+    test_fix2_partial_prefix_released_as_prose,
+    test_fix3_mismatched_plain_closer,
+    test_fix3_decorated_closer_halfwidth,
+    test_fix3_decorated_closer_fullwidth,
+    test_fix3_cross_family_closer,
+    test_flush_is_terminal_and_resets_state,
+    test_complete_blocks_unchanged,
+]
+
+
+def main():
+    failed = 0
+    for t in TESTS:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+    if failed:
+        sys.exit(1)
+    print(f"{len(TESTS)} tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# StreamToolParser: flush salvage, bounded hold, family-wide closer fallback

## Summary

Fixes the three edge cases flagged in review on `StreamToolParser` (functions.py), plus a regression suite. No API changes: `feed()` still returns `[{"text": ...} | {"tool": ...}]` and `flush()` the same, so `app.py`'s two streaming call sites are untouched.

## Changes

### FIX 1 — Unclosed wrapper drop in `flush()` (`functions.py`)

**Before:** if the stream was cut off before the closing tag arrived, `flush()` stripped wrapper tags and dumped the raw payload into the chat text — an attribute-style call like

```
<tool_call name="Bash"><parameter name="command">ls -la</parameter>
```

...ended up as `ls -la` in the chat transcript and the tool was lost.

**After:** `flush()` first falls back to `parse_tools(self.buffer)`; if the payload parses, the tool is emitted. Stripping-to-text only remains for genuinely unparseable leftovers (legacy behaviour). When `json_done` is set, post-JSON wrapper noise (e.g. a truncated `</tool_`) is dropped instead of leaking into the transcript. As a bonus, `parse_tools`' brace-balancing fallback recovers tools even from truncated-argument JSON (`{"command": "ls` → salvaged).

### FIX 2 — Bounded tag-prefix hold (`functions.py`)

The bare-`<` lookahead is now pinned by an explicit `_MAX_TAG_HOLD = 15` constant (longest start tag is 13 chars). Prose such as `if x < y` streams out immediately and can never buffer until `flush()`, regardless of future tag additions. Held tails are still exact prefixes of a real start tag, so nothing is held on a guess.

### FIX 3 — Family-wide closer fallback (`functions.py`)

End-tag detection in `feed()` is now a single compiled family regex instead of a fixed 4-string `find` list:

```python
_TOOL_END_TAG_RE = re.compile(
    r"</[｜\|]{0,2}(?:DSML[｜\|]{0,2})?(?:tool_calls?|invoke|function_call)>",
    re.IGNORECASE,
)
```

Mismatched closers (`</tool_calls>` closing `<tool_call>`, `</invoke>` closing `<function_call>`) and `|`/`｜`-decorated closers (`</|tool_call>`, `</｜tool_call>`) now close the block during `feed()` instead of hanging until `flush()` — decorated closers previously only worked by accident via the JSON path, and hung entirely for attribute-style calls.

## Tests

New `tests/test_stream_edge_cases.py` — 13 cases, one group per fix:

- FIX 1: attribute-style salvage, truncated-JSON salvage, wrapper-noise suppression, unparseable-payload legacy strip
- FIX 2: bare-`<` prose streaming, hold bound, partial-prefix release
- FIX 3: mismatched plain closer, halfwidth/fullwidth decorated closers, cross-family closer
- lifecycle guards (terminal flush/state reset, happy-path unchanged)

```
$ python tests/test_stream_edge_cases.py
13 tests passed
$ python tests/test_local_fixes.py
6 tests passed
```

Existing `test_local_fixes.py` passes unchanged; no behavioural regressions on complete, well-formed blocks.
